### PR TITLE
fix: checkout target if startPoint is empty

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10967,7 +10967,7 @@ async function run() {
             await exec.exec(`git --git-dir ${repoDir}/.git --work-tree ${repoDir} checkout --progress --force -B ${checkoutInfo.ref} ${checkoutInfo.startPoint}`);
         }
         else {
-            await exec.exec(`git --git-dir ${repoDir}/.git --work-tree ${repoDir} checkout --progress --force ${commit}`);
+            await exec.exec(`git --git-dir ${repoDir}/.git --work-tree ${repoDir} checkout --progress --force ${checkoutInfo.ref}`);
         }
         if (config.persistCredentials) {
             // Persist authentication in local

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,7 +97,7 @@ export async function run(): Promise<void> {
       )
     } else {
       await exec.exec(
-        `git --git-dir ${repoDir}/.git --work-tree ${repoDir} checkout --progress --force ${commit}`
+        `git --git-dir ${repoDir}/.git --work-tree ${repoDir} checkout --progress --force ${checkoutInfo.ref}`
       )
     }
 


### PR DESCRIPTION
## Description
This PR resolves an issue where the action was incorrectly checking out the latest code from the main branch, even when a specific ref (such as a sha, pull, or tag) was provided. 

The implementation has been updated to ensure that the target of the checkout is set to the specified ref.

## Issue Reproduction
To reproduce the issue, use the following workflow:

```yaml
    steps:
      - uses: namespacelabs/nscloud-checkout-action@v5
        with:
          ref: refs/tags/foo
      - run: git log
        # → latest commit logs shown...
```

As shown above, the action incorrectly checked out the latest commit from the main branch instead of the commit associated with refs/tags/foo.

## Testing
The fix was validated by running the action with various ref inputs (e.g., sha, pull, tag), confirming that the correct commit is checked out.

Please review the implementation to ensure no edge cases were missed.
