### PR TITLE
Prune references in the mirror when fetching.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10942,7 +10942,17 @@ See also https://namespace.so/docs/solutions/github-actions/caching#git-checkout
             await exec.exec('git', ['clone', '--mirror', '--', remoteURL, mirrorDir]);
         }
         // Fetch commits for mirror
-        await exec.exec('git', ['-c', 'protocol.version=2', '--git-dir', mirrorDir, 'fetch', '--no-recurse-submodules', 'origin']);
+        await exec.exec('git', [
+            '-c',
+            'protocol.version=2',
+            '--git-dir',
+            mirrorDir,
+            'fetch',
+            '--no-recurse-submodules',
+            '--prune',
+            '--prune-tags',
+            'origin'
+        ]);
         // If Git LFS is required, download objects in cache
         if (config.downloadGitLFS) {
             await exec.exec('git', ['--git-dir', mirrorDir, 'lfs', 'fetch', 'origin']);

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,17 @@ See also https://namespace.so/docs/solutions/github-actions/caching#git-checkout
     }
 
     // Fetch commits for mirror
-    await exec.exec('git', ['-c', 'protocol.version=2', '--git-dir', mirrorDir, 'fetch', '--no-recurse-submodules', 'origin'])
+    await exec.exec('git', [
+      '-c',
+      'protocol.version=2',
+      '--git-dir',
+      mirrorDir,
+      'fetch',
+      '--no-recurse-submodules',
+      '--prune',
+      '--prune-tags',
+      'origin'
+    ])
 
     // If Git LFS is required, download objects in cache
     if (config.downloadGitLFS) {


### PR DESCRIPTION
Consider a ref is deleted in the remote and then a new ref is created as a child (e.g. refs/heads/feature is deletede and refs/heads/feature/iteration is created). If we don't prune we run into a problem: we cannot create the iteration ref file in the feature directory because feature is a ref file itself:

    error: cannot lock ref 'refs/heads/feature/iteration': 'refs/heads/feature' exists; cannot create 'refs/heads/feature/iteration'

So here we first delete all refs in the mirror which don't exist in the remote.