### PR TITLE
feat: add mirror-refspec input to narrow mirror fetch refspecs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,3 +315,37 @@ jobs:
             echo "ERROR: uid 1001 should not have uid in cache path"
             exit 1
           fi
+
+  mirror-refspec:
+    name: Mirror with custom refspec
+    runs-on: [nscloud-ubuntu-22.04-amd64-2x4-with-cache, nscloud-git-mirror-5gb]
+    strategy:
+      fail-fast: false
+      matrix:
+        ref:
+          - ""
+          - "main"
+          - "refs/tags/v7.1.0"
+        fetch-depth:
+          - 0
+          - 1
+    steps:
+      - name: Check out action
+        uses: actions/checkout@v6
+      - name: Github checkout (reference)
+        uses: actions/checkout@v6
+        with:
+          path: github-ref
+          ref: ${{ matrix.ref }}
+          fetch-depth: ${{ matrix.fetch-depth }}
+      - name: Namespace checkout with mirror-refspec
+        uses: ./
+        with:
+          path: nscloud-refspec
+          ref: ${{ matrix.ref }}
+          fetch-depth: ${{ matrix.fetch-depth }}
+          mirror-refspec: |
+            +refs/heads/*:refs/heads/*
+            +refs/tags/*:refs/tags/*
+      - name: Compare checkouts
+        run: .github/tests/compare-checkouts.sh github-ref nscloud-refspec dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,15 @@ inputs:
     description: 'Enable git tracing (GIT_TRACE) for debugging.'
     default: "false"
 
+  mirror-refspec:
+    description: >
+      Refspecs to use when fetching into the Git mirror cache. Each refspec
+      should be on a separate line. When not specified, the mirror tracks all
+      refs (the default `git clone --mirror` behavior). Narrowing this to
+      e.g. only branches and tags can significantly speed up the mirror fetch
+      for repositories with many pull requests.
+    default: ""
+
 runs:
   using: node20
   main: dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.11.tgz",
       "integrity": "sha512-lh7RJrtPdhibbxndr6/xx0w8+CVlY5FJZiaSz908Fpy+G0xkBFTvwLcKJFF4PJxVfGhVWNebikpWGnOoC71juQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.10",
@@ -1209,7 +1208,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1413,7 +1411,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
       "integrity": "sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -1722,7 +1719,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2177,7 +2173,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001517",
         "electron-to-chromium": "^1.4.477",
@@ -2868,7 +2863,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
       "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4550,7 +4544,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5948,7 +5941,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
       "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7026,7 +7018,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Summary

- Add `mirror-refspec` input that allows users to specify custom refspecs for the Git mirror fetch, so repositories with many pull requests can skip fetching `refs/pull/*` and significantly reduce mirror update time
- When not specified, behavior is unchanged (full `--mirror` fetch)
- Conditionally omit `--prune-tags` when the custom refspecs don't include tags

## Test plan

- [ ] Existing CI tests pass (backward compatibility)
- [ ] New `mirror-refspec` CI job compares namespace checkout with custom refspecs against `actions/checkout` across ref types (`""`, `main`, `refs/tags/v7.1.0`) and fetch depths (`0`, `1`)