### PR TITLE
Add cancel-stalling-git-operations input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,11 @@ inputs:
     description: 'Enable git tracing (GIT_TRACE) for debugging.'
     default: "false"
 
+  cancel-stalling-git-operations:
+    description: >
+      Abort git HTTP transfers that stall (below ~1 KB/s for 60s), so the inbuilt retry logic kicks in.
+    default: "true"
+
 runs:
   using: node24
   main: dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -31722,6 +31722,10 @@ function parseInputConfig() {
     core.debug(`maxAttempts = ${result.maxAttempts}`);
     result.trace = core.getInput('trace').toUpperCase() === 'TRUE';
     core.debug(`trace = ${result.trace}`);
+    // Default true: abort stalled HTTP transfers via libcurl low-speed limit so
+    // the existing retry path can take over instead of hanging indefinitely.
+    result.cancelStallingGitOperations = core.getInput('cancel-stalling-git-operations').toUpperCase() !== 'FALSE';
+    core.debug(`cancelStallingGitOperations = ${result.cancelStallingGitOperations}`);
     return result;
 }
 async function getCheckoutInfo(ref, commit, depth, mirrorDir) {
@@ -31863,6 +31867,20 @@ function getGitExecOptions(options) {
     if (traceEnabled) {
         gitEnv.GIT_TRACE = '1';
         gitEnv.GIT_TRACE_PACK_ACCESS = '1';
+    }
+    // Abort HTTP transfers stalled below 1 KB/s for 60s so the existing retry path
+    // (max-attempts) takes over instead of the operation hanging forever. The env
+    // vars are inherited by every git child process, including those spawned by
+    // `git submodule update` and by `nsc git-checkout`. Defer to user-provided
+    // values in process.env so workflow-level overrides win.
+    const cancelStallingEnabled = core.getInput('cancel-stalling-git-operations').toUpperCase() !== 'FALSE';
+    if (cancelStallingEnabled) {
+        if (!process.env.GIT_HTTP_LOW_SPEED_LIMIT) {
+            gitEnv.GIT_HTTP_LOW_SPEED_LIMIT = '1000';
+        }
+        if (!process.env.GIT_HTTP_LOW_SPEED_TIME) {
+            gitEnv.GIT_HTTP_LOW_SPEED_TIME = '60';
+        }
     }
     return {
         ...options,

--- a/src/main.ts
+++ b/src/main.ts
@@ -231,6 +231,7 @@ interface IInputConfig {
   downloadGitLFS: boolean
   maxAttempts: number
   trace: boolean
+  cancelStallingGitOperations: boolean
 }
 
 function parseInputConfig(): IInputConfig {
@@ -336,6 +337,11 @@ function parseInputConfig(): IInputConfig {
 
   result.trace = core.getInput('trace').toUpperCase() === 'TRUE'
   core.debug(`trace = ${result.trace}`)
+
+  // Default true: abort stalled HTTP transfers via libcurl low-speed limit so
+  // the existing retry path can take over instead of hanging indefinitely.
+  result.cancelStallingGitOperations = core.getInput('cancel-stalling-git-operations').toUpperCase() !== 'FALSE'
+  core.debug(`cancelStallingGitOperations = ${result.cancelStallingGitOperations}`)
 
   return result
 }
@@ -517,6 +523,21 @@ function getGitExecOptions(options?: exec.ExecOptions): exec.ExecOptions {
   if (traceEnabled) {
     gitEnv.GIT_TRACE = '1'
     gitEnv.GIT_TRACE_PACK_ACCESS = '1'
+  }
+
+  // Abort HTTP transfers stalled below 1 KB/s for 60s so the existing retry path
+  // (max-attempts) takes over instead of the operation hanging forever. The env
+  // vars are inherited by every git child process, including those spawned by
+  // `git submodule update` and by `nsc git-checkout`. Defer to user-provided
+  // values in process.env so workflow-level overrides win.
+  const cancelStallingEnabled = core.getInput('cancel-stalling-git-operations').toUpperCase() !== 'FALSE'
+  if (cancelStallingEnabled) {
+    if (!process.env.GIT_HTTP_LOW_SPEED_LIMIT) {
+      gitEnv.GIT_HTTP_LOW_SPEED_LIMIT = '1000'
+    }
+    if (!process.env.GIT_HTTP_LOW_SPEED_TIME) {
+      gitEnv.GIT_HTTP_LOW_SPEED_TIME = '60'
+    }
   }
 
   return {


### PR DESCRIPTION
Adds a new input (default true) that sets GIT_HTTP_LOW_SPEED_LIMIT=1000 and GIT_HTTP_LOW_SPEED_TIME=60 on every git invocation. Git's libcurl HTTP transport aborts a transfer that stays below 1 KB/s for 60s, which returns a non-zero exit code so the existing max-attempts retry path can take over instead of the operation hanging indefinitely.

The env vars are inherited by every git child process, including those spawned by 'git submodule update' and by 'nsc git-checkout', so the protection covers the full submodule walk without further plumbing.

Workflow-level overrides win: if the user sets
GIT_HTTP_LOW_SPEED_LIMIT / GIT_HTTP_LOW_SPEED_TIME in their workflow env, those values are kept. Set cancel-stalling-git-operations: false to disable entirely.

Amp-Thread-ID: https://ampcode.com/threads/T-019df20f-8464-75f8-9e23-2bd6a9af0c5e